### PR TITLE
Use the vagrant SSH key for the tutorial.

### DIFF
--- a/step-00/README.md
+++ b/step-00/README.md
@@ -25,21 +25,12 @@ to type your password since it needs to sudo as root).
 If something goes wrong, refer to Vagrant's [Getting Started
 Guide](http://docs.vagrantup.com/v2/getting-started/index.html).
 
-# Adding your SSH keys on the virtual machines
+# SSH keys on the virtual machines
 
-To follow this tutorial, you'll need to have your keys in VMs root's `authorized_keys`. 
-While this is not absolutely necessary (Ansible can use sudo, password authentication, 
-etc...), it will make things way easier.
+Vagrant installs an key for SSH automatically. To use this key during the tutorial add it to your ssh-agent:
 
-Ansible is perfect for this and we will use it for the job. However I won't
-explain what's happening for now. Just trust me.
-
-    ansible-playbook -i step-00/hosts step-00/setup.yml --ask-pass --sudo
-
-When asked for password, enter _vagrant_.
-
-To polish things up, it's better to have an ssh-agent running, and add your keys 
-to it (`ssh-add`).
+    ssh-add ~/.vagrant.d/insecure_private_key
+Identity added: .../.vagrant.d/insecure_private_key (.../.vagrant.d/insecure_private_key)
 
 Now head to the first step in `./step-01` (or click
 [here](https://github.com/leucos/ansible-tuto/tree/master/step-01)).

--- a/step-00/setup.yml
+++ b/step-00/setup.yml
@@ -1,43 +1,14 @@
 - hosts: all
-  sudo: True
-  
+
   tasks:
-    # This should work too / #2372
-    # - name: Pushes user key to root's on vagrant boxes
-    #   action: authorized_key key=$FILE($item) user=root
-    #   first_available_file:
-    #     - ~/.ssh/id_dsa.pub
-    #     - ~/.ssh/id_rsa.pub
-
-    - name: Creates destination directory
-      # Workaround for #2372
-      file: state=directory mode=0700 dest=/root/.ssh/
-      
-    - name: Pushes user's rsa key to root's vagrant box (it's ok if this TASK fails)
-      # action: authorized_key user=root key='$FILE(~/.ssh/id_rsa.pub)'
-      # Workaround for #2372
-      action: copy src=~/.ssh/id_rsa.pub dest=/root/.ssh/authorized_keys owner=root mode=0600
-      register: rsa
-      ignore_errors: yes
-
-    - name: Pushes user's dsa key to root's vagrant box (it's NOT ok if both TASKs fail)
-      # action: authorized_key user=root key='$FILE(~/.ssh/id_dsa.pub)'
-      # Workaround for #2372
-      action: copy src=~/.ssh/id_dsa.pub dest=/root/.ssh/authorized_keys owner=root mode=0600
-      when_failed: $rsa
-
     - name: Checks if resolver is working properly (issues with some VBox/Host OS combinations)
       action: command host -t A ansible.cc
       register: ns
       ignore_errors: yes
 
-    - name: Pushes new resolver configuration is resolver fails
+    - name: Pushes new resolver configuration if resolver fails
       action: lineinfile regexp="^nameserver " line="nameserver 8.8.8.8" dest=/etc/resolv.conf
       when_failed: $ns
 
     - name: Checks if resolver is working properly with new nameserver
       action: command host -t A ansible.cc
-
-    - name: Final greeting
-      action: pause prompt="Don't worry about all the red above; if you made it here, your Vagrant VMs are probably fine !
-        Please press [Enter]"

--- a/step-01/README.md
+++ b/step-01/README.md
@@ -10,9 +10,9 @@ flag in ansible commands an provide the inventory path.
 
 We've created an inventory file for you in the directory that looks like this :
 
-    host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=root
-    host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
-    host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=root
+    host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant
+    host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant
+    host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=vagrant
 
 `ansible_ssh_host` is a special _variable_ that sets the IP ansible will use 
 when trying to connect to this host. It's not necessary here if you use the 

--- a/step-01/hosts
+++ b/step-01/hosts
@@ -1,3 +1,3 @@
-host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=root
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
-host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=root
+host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant
+host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=vagrant

--- a/step-02/README.md
+++ b/step-02/README.md
@@ -85,7 +85,7 @@ called `setup`: it specializes in node's _facts_ gathering.
 
 Try it out:
 
-    ansible -m setup host0.example.org
+    ansible -i step-02/hosts -m setup host0.example.org
 
 replies with lots of information :
 
@@ -109,7 +109,7 @@ It's been truncated for brevity, but you can find many interesting bits in the r
 data. You may also filter returned keys, in case you're looking for something specific.
 
 For instance, let's say you want to know how much memory you have on all your hosts, 
-easy with `ansible -m setup -a 'filter=ansible_memtotal_mb' all` :
+easy with `ansible -i step-02/hosts -m setup -a 'filter=ansible_memtotal_mb' all` :
 
     host2.example.org | success >> {
         "ansible_facts": {

--- a/step-02/hosts
+++ b/step-02/hosts
@@ -1,3 +1,3 @@
-host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=root
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
-host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=root
+host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant
+host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=vagrant

--- a/step-04/README.md
+++ b/step-04/README.md
@@ -27,6 +27,7 @@ In any case, use a non-critical machine to play with!
 Lets build a playbook that will install apache on machines in the `web` group.
 
     - hosts: web
+      sudo: True
       tasks:
         - name: Installs apache web server
           action: apt pkg=apache2 state=installed update_cache=true

--- a/step-04/apache.yml
+++ b/step-04/apache.yml
@@ -1,4 +1,5 @@
-    - hosts: web
-      tasks:
-        - name: Installs apache web server
-          action: apt pkg=apache2 state=installed update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Installs apache web server
+      action: apt pkg=apache2 state=installed update_cache=true

--- a/step-04/hosts
+++ b/step-04/hosts
@@ -1,2 +1,2 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant

--- a/step-05/README.md
+++ b/step-05/README.md
@@ -28,6 +28,7 @@ for host1.example.org, which we'll call `awesome-app` :
 Now, a quick update to our apache playbook and we're set :
 
     - hosts: web
+      sudo: True
       tasks:
         - name: Installs apache web server
           action: apt pkg=apache2 state=installed update_cache=true

--- a/step-05/apache.yml
+++ b/step-05/apache.yml
@@ -1,22 +1,23 @@
-    - hosts: web
-      tasks:
-        - name: Installs apache web server
-          action: apt pkg=apache2 state=installed update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Installs apache web server
+      action: apt pkg=apache2 state=installed update_cache=true
 
-        - name: Push default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640 
+    - name: Push default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640 
 
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
-          notify:
-            - restart apache
-            
-      handlers:
-        - name: restart apache
-          action: service name=apache2 state=restarted
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
+      notify:
+        - restart apache
+
+  handlers:
+    - name: restart apache
+      action: service name=apache2 state=restarted

--- a/step-05/hosts
+++ b/step-05/hosts
@@ -1,2 +1,2 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant

--- a/step-06/README.md
+++ b/step-06/README.md
@@ -35,6 +35,7 @@ playbook already, the default virtualhost is already deactivated. Nevermind :
 this playbook might be used on other innocent hosts, so let's protect them.
 
     - hosts: web
+      sudo: True
       tasks:
         - name: Installs apache web server
           action: apt pkg=apache2 state=installed update_cache=true

--- a/step-06/apache.yml
+++ b/step-06/apache.yml
@@ -1,25 +1,26 @@
-    - hosts: web
-      tasks:
-        - name: Installs apache web server
-          action: apt pkg=apache2 state=installed update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Installs apache web server
+      action: apt pkg=apache2 state=installed update_cache=true
 
-        - name: Push future default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+    - name: Push future default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
 
-        - name: Check that our config is valid
-          action: command apache2ctl configtest
-        
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Check that our config is valid
+      action: command apache2ctl configtest
 
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
-          notify: 
-            - restart apache
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-      handlers:
-        - name: restart apache
-          action: service name=apache2 state=restarted
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
+      notify: 
+        - restart apache
+
+  handlers:
+    - name: restart apache
+      action: service name=apache2 state=restarted

--- a/step-06/hosts
+++ b/step-06/hosts
@@ -1,2 +1,2 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant

--- a/step-07/README.md
+++ b/step-07/README.md
@@ -21,6 +21,7 @@ processing if there is a failure but only to revert what we've done.
 
 
     - hosts: web
+      sudo: True
       tasks:
         - name: Installs apache web server
           action: apt pkg=apache2 state=installed update_cache=true
@@ -62,7 +63,7 @@ processing if there is a failure but only to revert what we've done.
           action: service name=apache2 state=restarted
 
 The `register` keyword records output from the `apache2ctl configtest` command (exit 
-status, stdout, stderr, ...), and `when_failed` checks if the registered variable 
+status, stdout, stderr, ...), and `when` checks if the registered variable 
 contains a failed status.
 
 Here we go :
@@ -108,7 +109,7 @@ Here we go :
 
 Seemed to work as expected. Let's try to restart apache to see if it really worked:
 
-    $ ansible -i step-07/hosts -m service -a 'name=apache2 state=restarted' host1.example.org
+    $ ansible -i step-07/hosts -m service -a 'name=apache2 state=restarted' host1.example.org -sudo
     host1.example.org | success >> {
         "changed": true, 
         "name": "apache2", 

--- a/step-07/apache.yml
+++ b/step-07/apache.yml
@@ -1,40 +1,41 @@
-    - hosts: web
-      tasks:
-        - name: Installs apache web server
-          action: apt pkg=apache2 state=installed update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Installs apache web server
+      action: apt pkg=apache2 state=installed update_cache=true
 
-        - name: Push future default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+    - name: Push future default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
 
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
 
-        - name: Check that our config is valid
-          action: command apache2ctl configtest
-          register: result
-          ignore_errors: True
+    - name: Check that our config is valid
+      action: command apache2ctl configtest
+      register: result
+      ignore_errors: True
 
-        - name: Rolling back - Restoring old default virtualhost
-          action: command a2ensite default
-          when: result|failed
+    - name: Rolling back - Restoring old default virtualhost
+      action: command a2ensite default
+      when: result|failed
 
-        - name: Rolling back - Removing out virtualhost
-          action: command a2dissite awesome-app
-          when: result|failed
+    - name: Rolling back - Removing out virtualhost
+      action: command a2dissite awesome-app
+      when: result|failed
 
-        - name: Rolling back - Ending playbook
-          action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
-          when: result|failed
-        
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
+    - name: Rolling back - Ending playbook
+      action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
+      when: result|failed
 
-          notify:
-            - restart apache
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
 
-      handlers:
-        - name: restart apache
-          action: service name=httpd state=restarted
+      notify:
+        - restart apache
+
+  handlers:
+    - name: restart apache
+      action: service name=httpd state=restarted

--- a/step-07/hosts
+++ b/step-07/hosts
@@ -1,2 +1,2 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant

--- a/step-08/README.md
+++ b/step-08/README.md
@@ -36,6 +36,7 @@ of items, and use each item in an action like this:
 
 
     - hosts: web
+      sudo: True
       tasks:
         - name: Updates apt cache
           action: apt update_cache=true

--- a/step-08/apache.yml
+++ b/step-08/apache.yml
@@ -1,50 +1,51 @@
-    - hosts: web
-      tasks:
-        - name: Updates apt cache
-          action: apt update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Updates apt cache
+      action: apt update_cache=true
 
-        - name: Installs necessary packages
-          action: apt pkg=$item state=latest 
-          with_items:
-            - apache2
-            - libapache2-mod-php5
-            - git
+    - name: Installs necessary packages
+      action: apt pkg=$item state=latest 
+      with_items:
+        - apache2
+        - libapache2-mod-php5
+        - git
 
-        - name: Push future default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+    - name: Push future default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
 
-        - name: Check that our config is valid
-          action: command apache2ctl configtest
-          register: result
-          ignore_errors: True
+    - name: Check that our config is valid
+      action: command apache2ctl configtest
+      register: result
+      ignore_errors: True
 
-        - name: Rolling back - Restoring old default virtualhost
-          action: command a2ensite default
-          when: result|failed
+    - name: Rolling back - Restoring old default virtualhost
+      action: command a2ensite default
+      when: result|failed
 
-        - name: Rolling back - Removing out virtualhost
-          action: command a2dissite awesome-app
-          when: result|failed
+    - name: Rolling back - Removing out virtualhost
+      action: command a2dissite awesome-app
+      when: result|failed
 
-        - name: Rolling back - Ending playbook
-          action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
-          when: result|failed
+    - name: Rolling back - Ending playbook
+      action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
+      when: result|failed
 
-        - name: Deploy our awesome application
-          action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
-          tags: deploy
+    - name: Deploy our awesome application
+      action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
+      tags: deploy
 
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
-          notify:
-            - restart apache
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
+      notify:
+        - restart apache
 
-      handlers:
-        - name: restart apache
-          action: service name=apache2 state=restarted
+  handlers:
+    - name: restart apache
+      action: service name=apache2 state=restarted

--- a/step-08/hosts
+++ b/step-08/hosts
@@ -1,2 +1,2 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant

--- a/step-09/apache.yml
+++ b/step-09/apache.yml
@@ -1,50 +1,51 @@
-    - hosts: web
-      tasks:
-        - name: Updates apt cache
-          action: apt update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Updates apt cache
+      action: apt update_cache=true
 
-        - name: Installs necessary packages
-          action: apt pkg=$item state=latest 
-          with_items:
-            - apache2
-            - libapache2-mod-php5
-            - git
+    - name: Installs necessary packages
+      action: apt pkg=$item state=latest 
+      with_items:
+        - apache2
+        - libapache2-mod-php5
+        - git
 
-        - name: Push future default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+    - name: Push future default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
 
-        - name: Check that our config is valid
-          action: command apache2ctl configtest
-          register: result
-          ignore_errors: True
+    - name: Check that our config is valid
+      action: command apache2ctl configtest
+      register: result
+      ignore_errors: True
 
-        - name: Rolling back - Restoring old default virtualhost
-          action: command a2ensite default
-          when_failed: $result
+    - name: Rolling back - Restoring old default virtualhost
+      action: command a2ensite default
+      when_failed: $result
 
-        - name: Rolling back - Removing out virtualhost
-          action: command a2dissite awesome-app
-          when_failed: $result
+    - name: Rolling back - Removing out virtualhost
+      action: command a2dissite awesome-app
+      when_failed: $result
 
-        - name: Rolling back - Ending playbook
-          action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
-          when_failed: $result
+    - name: Rolling back - Ending playbook
+      action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
+      when_failed: $result
 
-        - name: Deploy our awesome application
-          action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
-          tags: deploy
+    - name: Deploy our awesome application
+      action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
+      tags: deploy
 
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
-          notify:
-            - restart apache
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
+      notify:
+        - restart apache
 
-      handlers:
-        - name: restart apache
-          action: service name=apache2 state=restarted
+  handlers:
+    - name: restart apache
+      action: service name=apache2 state=restarted

--- a/step-09/hosts
+++ b/step-09/hosts
@@ -1,6 +1,6 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
-host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant
+host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=vagrant
 
 [haproxy]
-host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=root
+host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant

--- a/step-10/README.md
+++ b/step-10/README.md
@@ -58,6 +58,7 @@ We've done the most difficult part of the job. Writing a playbook to install and
 configure HAproxy is a breeze:
 
     - hosts: haproxy
+      sudo: True
       tasks:
         - name: Installs haproxy load balancer
           action: apt pkg=haproxy state=installed update_cache=yes

--- a/step-10/apache.yml
+++ b/step-10/apache.yml
@@ -1,50 +1,51 @@
-    - hosts: web
-      tasks:
-        - name: Updates apt cache
-          action: apt update_cache=true
+- hosts: web
+  sudo: True
+  tasks:
+    - name: Updates apt cache
+      action: apt update_cache=true
 
-        - name: Installs necessary packages
-          action: apt pkg=$item state=latest 
-          with_items:
-            - apache2
-            - libapache2-mod-php5
-            - git
+    - name: Installs necessary packages
+      action: apt pkg=$item state=latest 
+      with_items:
+        - apache2
+        - libapache2-mod-php5
+        - git
 
-        - name: Push future default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+    - name: Push future default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
 
-        - name: Check that our config is valid
-          action: command apache2ctl configtest
-          register: result
-          ignore_errors: True
+    - name: Check that our config is valid
+      action: command apache2ctl configtest
+      register: result
+      ignore_errors: True
 
-        - name: Rolling back - Restoring old default virtualhost
-          action: command a2ensite default
-          when_failed: $result
+    - name: Rolling back - Restoring old default virtualhost
+      action: command a2ensite default
+      when_failed: $result
 
-        - name: Rolling back - Removing out virtualhost
-          action: command a2dissite awesome-app
-          when_failed: $result
+    - name: Rolling back - Removing out virtualhost
+      action: command a2dissite awesome-app
+      when_failed: $result
 
-        - name: Rolling back - Ending playbook
-          action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
-          when_failed: $result
+    - name: Rolling back - Ending playbook
+      action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
+      when_failed: $result
 
-        - name: Deploy our awesome application
-          action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
-          tags: deploy
+    - name: Deploy our awesome application
+      action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
+      tags: deploy
 
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
-          notify:
-            - restart apache
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
+      notify:
+        - restart apache
 
-      handlers:
-        - name: restart apache
-          action: service name=apache2 state=restarted
+  handlers:
+    - name: restart apache
+      action: service name=apache2 state=restarted

--- a/step-10/haproxy.yml
+++ b/step-10/haproxy.yml
@@ -1,4 +1,5 @@
 - hosts: haproxy
+  sudo: True
   tasks:
     - name: Installs haproxy load balancer
       action: apt pkg=haproxy state=installed update_cache=yes

--- a/step-10/hosts
+++ b/step-10/hosts
@@ -1,6 +1,6 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
-host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant
+host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=vagrant
 
 [haproxy]
-host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=root
+host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant

--- a/step-11/README.md
+++ b/step-11/README.md
@@ -94,11 +94,13 @@ changed, but we had to cheat a bit for that. Here is the updated haproxy playboo
 :
 
     - hosts: web
+      sudo: True
       tasks: 
         - name : Fake task to gather facts
           action: debug msg="done"
           
     - hosts: haproxy
+      sudo: True
       tasks:
         - name: Installs haproxy load balancer
           action: apt pkg=haproxy state=installed update_cache=yes

--- a/step-11/apache.yml
+++ b/step-11/apache.yml
@@ -1,50 +1,52 @@
-    - hosts: web
-      tasks:
-        - name: Updates apt cache
-          action: apt update_cache=true
+- hosts: web
+  sudo: True
 
-        - name: Installs necessary packages
-          action: apt pkg=$item state=latest 
-          with_items:
-            - apache2
-            - libapache2-mod-php5
-            - git
+  tasks:
+    - name: Updates apt cache
+      action: apt update_cache=true
 
-        - name: Push future default virtual host configuration
-          action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+    - name: Installs necessary packages
+      action: apt pkg=$item state=latest 
+      with_items:
+        - apache2
+        - libapache2-mod-php5
+        - git
 
-        - name: Activates our virtualhost
-          action: command a2ensite awesome-app
+    - name: Push future default virtual host configuration
+      action: copy src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
 
-        - name: Check that our config is valid
-          action: command apache2ctl configtest
-          register: result
-          ignore_errors: True
+    - name: Activates our virtualhost
+      action: command a2ensite awesome-app
 
-        - name: Rolling back - Restoring old default virtualhost
-          action: command a2ensite default
-          when_failed: $result
+    - name: Check that our config is valid
+      action: command apache2ctl configtest
+      register: result
+      ignore_errors: True
 
-        - name: Rolling back - Removing out virtualhost
-          action: command a2dissite awesome-app
-          when_failed: $result
+    - name: Rolling back - Restoring old default virtualhost
+      action: command a2ensite default
+      when_failed: $result
 
-        - name: Rolling back - Ending playbook
-          action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
-          when_failed: $result
+    - name: Rolling back - Removing out virtualhost
+      action: command a2dissite awesome-app
+      when_failed: $result
 
-        - name: Deploy our awesome application
-          action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
-          tags: deploy
+    - name: Rolling back - Ending playbook
+      action: fail msg="Configuration file is not valid. Please check that before re-running the playbook."
+      when_failed: $result
 
-        - name: Deactivates the default virtualhost
-          action: command a2dissite default
+    - name: Deploy our awesome application
+      action: git repo=https://github.com/leucos/ansible-tuto-demosite.git dest=/var/www/awesome-app
+      tags: deploy
 
-        - name: Deactivates the default ssl virtualhost
-          action: command a2dissite default-ssl
-          notify:
-            - restart apache
+    - name: Deactivates the default virtualhost
+      action: command a2dissite default
 
-      handlers:
-        - name: restart apache
-          action: service name=apache2 state=restarted
+    - name: Deactivates the default ssl virtualhost
+      action: command a2dissite default-ssl
+      notify:
+        - restart apache
+
+  handlers:
+    - name: restart apache
+      action: service name=apache2 state=restarted

--- a/step-11/haproxy.yml
+++ b/step-11/haproxy.yml
@@ -1,9 +1,13 @@
 - hosts: web
+  sudo: True
+
   tasks: 
     - name : Fake task to gather facts
       action: debug msg="done"
-      
+
 - hosts: haproxy
+  sudo: True
+
   tasks:
     - name: Installs haproxy load balancer
       action: apt pkg=haproxy state=installed update_cache=yes

--- a/step-11/hosts
+++ b/step-11/hosts
@@ -1,6 +1,6 @@
 [web]
-host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=root
-host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=root
+host1.example.org ansible_ssh_host=192.168.33.11 ansible_ssh_user=vagrant
+host2.example.org ansible_ssh_host=192.168.33.12 ansible_ssh_user=vagrant
 
 [haproxy]
-host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=root
+host0.example.org ansible_ssh_host=192.168.33.10 ansible_ssh_user=vagrant


### PR DESCRIPTION
This avoids the need to install ssh-pass for step-00.

I'm not necessarily advocating the entire tutorial should be changed to this, but rather than installing ssh-pass I thought it would be better to use an ssh-agent and the default vagrant key.

Interested in your thoughts, thanks.
