### PR TITLE
Compatibilty changes for Apache 2.4 (used by trusty32)

### DIFF
--- a/step-05/apache.yml
+++ b/step-05/apache.yml
@@ -4,20 +4,20 @@
           apt: pkg=apache2 state=installed update_cache=true
 
         - name: Push default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app mode=0640 
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640 
 
         - name: Disable the default virtualhost
-          file: dest=/etc/apache2/sites-enabled/default state=absent
+          file: dest=/etc/apache2/sites-enabled/000-default.conf state=absent
           notify:
             - restart apache
 
         - name: Disable the default ssl virtualhost
-          file: dest=/etc/apache2/sites-enabled/default-ssl state=absent
+          file: dest=/etc/apache2/sites-enabled/default-ssl.conf state=absent
           notify:
             - restart apache
 
         - name: Activates our virtualhost
-          file: src=/etc/apache2/sites-available/awesome-app dest=/etc/apache2/sites-enabled/awesome-app state=link
+          file: src=/etc/apache2/sites-available/awesome-app.conf dest=/etc/apache2/sites-enabled/awesome-app.conf state=link
           notify:
             - restart apache
             

--- a/step-06/apache.yml
+++ b/step-06/apache.yml
@@ -4,7 +4,7 @@
           apt: pkg=apache2 state=installed update_cache=true
 
         - name: Push future default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
         - name: Activates our virtualhost
           command: a2ensite awesome-app
@@ -13,7 +13,7 @@
           command: apache2ctl configtest
         
         - name: Deactivates the default virtualhost
-          command: a2dissite default
+          command: a2dissite 000-default
 
         - name: Deactivates the default ssl virtualhost
           command: a2dissite default-ssl

--- a/step-07/apache.yml
+++ b/step-07/apache.yml
@@ -4,10 +4,10 @@
           apt: pkg=apache2 state=installed update_cache=true
 
         - name: Push future default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
         - name: Deactivates the default virtualhost
-          command: a2dissite default
+          command: a2dissite 000-default
 
         - name: Activates our virtualhost
           command: a2ensite awesome-app
@@ -18,7 +18,7 @@
           ignore_errors: True
 
         - name: Rolling back - Restoring old default virtualhost
-          command: a2ensite default
+          command: a2ensite 000-default
           when: result|failed
 
         - name: Rolling back - Removing out virtualhost
@@ -37,4 +37,4 @@
 
       handlers:
         - name: restart apache
-          service: name=httpd state=restarted
+          service: name=apache2 state=restarted

--- a/step-08/apache.yml
+++ b/step-08/apache.yml
@@ -11,7 +11,7 @@
             - git
 
         - name: Push future default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
         - name: Activates our virtualhost
           command: a2ensite awesome-app
@@ -22,7 +22,7 @@
           ignore_errors: True
 
         - name: Rolling back - Restoring old default virtualhost
-          command: a2ensite default
+          command: a2ensite 000-default
           when: result|failed
 
         - name: Rolling back - Removing out virtualhost
@@ -38,7 +38,7 @@
           tags: deploy
 
         - name: Deactivates the default virtualhost
-          command: a2dissite default
+          command: a2dissite 000-default
 
         - name: Deactivates the default ssl virtualhost
           command: a2dissite default-ssl

--- a/step-09/apache.yml
+++ b/step-09/apache.yml
@@ -11,7 +11,7 @@
             - git
 
         - name: Push future default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
         - name: Activates our virtualhost
           command: a2ensite awesome-app
@@ -22,7 +22,7 @@
           ignore_errors: True
 
         - name: Rolling back - Restoring old default virtualhost
-          command: a2ensite default
+          command: a2ensite 000-default
           when: result|failed
 
         - name: Rolling back - Removing out virtualhost
@@ -38,7 +38,7 @@
           tags: deploy
 
         - name: Deactivates the default virtualhost
-          command: a2dissite default
+          command: a2dissite 000-default
 
         - name: Deactivates the default ssl virtualhost
           command: a2dissite default-ssl

--- a/step-10/apache.yml
+++ b/step-10/apache.yml
@@ -11,7 +11,7 @@
             - git
 
         - name: Push future default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
         - name: Activates our virtualhost
           command: a2ensite awesome-app
@@ -22,7 +22,7 @@
           ignore_errors: True
 
         - name: Rolling back - Restoring old default virtualhost
-          command: a2ensite default
+          command: a2ensite 000-default
           when: result|failed
 
         - name: Rolling back - Removing out virtualhost
@@ -38,7 +38,7 @@
           tags: deploy
 
         - name: Deactivates the default virtualhost
-          command: a2dissite default
+          command: a2dissite 000-default
 
         - name: Deactivates the default ssl virtualhost
           command: a2dissite default-ssl

--- a/step-11/apache.yml
+++ b/step-11/apache.yml
@@ -11,7 +11,7 @@
             - git
 
         - name: Push future default virtual host configuration
-          copy: src=files/awesome-app dest=/etc/apache2/sites-available/ mode=0640
+          copy: src=files/awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
         - name: Activates our virtualhost
           command: a2ensite awesome-app
@@ -22,7 +22,7 @@
           ignore_errors: True
 
         - name: Rolling back - Restoring old default virtualhost
-          command: a2ensite default
+          command: a2ensite 000-default
           when: result|failed
 
         - name: Rolling back - Removing out virtualhost
@@ -38,7 +38,7 @@
           tags: deploy
 
         - name: Deactivates the default virtualhost
-          command: a2dissite default
+          command: a2dissite 000-default
 
         - name: Deactivates the default ssl virtualhost
           command: a2dissite default-ssl

--- a/step-12/roles/apache/tasks/main.yml
+++ b/step-12/roles/apache/tasks/main.yml
@@ -9,7 +9,7 @@
     - git
 
 - name: Push future default virtual host configuration
-  copy: src=awesome-app dest=/etc/apache2/sites-available/ mode=0640
+  copy: src=awesome-app dest=/etc/apache2/sites-available/awesome-app.conf mode=0640
 
 - name: Activates our virtualhost
   command: a2ensite awesome-app
@@ -20,7 +20,7 @@
   ignore_errors: True
 
 - name: Rolling back - Restoring old default virtualhost
-  command: a2ensite default
+  command: a2ensite 000-default
   when: result|failed
 
 - name: Rolling back - Removing out virtualhost
@@ -36,7 +36,7 @@
   tags: deploy
 
 - name: Deactivates the default virtualhost
-  command: a2dissite default
+  command: a2dissite 000-default
 
 - name: Deactivates the default ssl virtualhost
   command: a2dissite default-ssl


### PR DESCRIPTION
- Config files now must end in .conf
- Default site is now 000-default.

Changing the default Vagrant box to trusty32  broke the web installs.  This PR fixes this.

test/run.sh passes.