### PR TITLE
add stats uri for haproxy to template

### DIFF
--- a/step-10/templates/haproxy.cfg.j2
+++ b/step-10/templates/haproxy.cfg.j2
@@ -12,6 +12,7 @@ listen cluster
     bind {{ ansible_eth1['ipv4']['address'] }}:80
     mode http
     stats enable
+    stats uri  /haproxy?stats
     balance roundrobin
 {% for backend in groups['web'] %}
     server {{ hostvars[backend]['ansible_hostname'] }} {{ hostvars[backend]['ansible_eth1']['ipv4']['address'] }} check port 80


### PR DESCRIPTION
Hi,
this is somewhat ad-hoc, so probably I missed something.
I was going through the tutorial and it went well (thanks!) until step10 mentioned haproxy stats. These stats weren't working on my machine, so I adjusted the template following this [haproxy guide](http://tecadmin.net/how-to-configure-haproxy-statics/#). It may very well be that the default uri has changed at some point, but this fixed it for me.

Are the files linked between the steps somehow or do I have to manually propagate this change to later steps?

Kind regards,
Matthias