### PR TITLE
Refer to the interactive version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ git clone https://github.com/leucos/ansible-tuto.git
 cd ansible-tuto
 ```
 
-# Running tutorials interactively with docker
+# Running the tutorials interactively with Docker
 
-You can make a quick start with a very simple setup via docker and also run the tutorials here interactively.
+You can run the tutorials here interactively including a very simple setup with docker.
 
-Check [this repository](https://github.com/turkenh/ansible-interactive-tutorial).
+Check [this repository](https://github.com/turkenh/ansible-interactive-tutorial) for details.
 
 # Using Vagrant with the tutorial
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ git clone https://github.com/leucos/ansible-tuto.git
 cd ansible-tuto
 ```
 
+# Running tutorials interactively with docker
+
+You can make a quick start with a very simple setup via docker and also run the tutorials here interactively.
+
+Check [this repository](https://github.com/turkenh/ansible-interactive-tutorial).
+
 # Using Vagrant with the tutorial
 
 It's highly recommended to use Vagrant to follow this tutorial. If you don't have 


### PR DESCRIPTION
Hi,

I've created interactive versions of the tutorials here including a very simple setup with docker.

I want to refer to [that repository](https://github.com/turkenh/ansible-interactive-tutorial) in the README, so that people can make a very quick start and also run the tutorials interactively if they are interested.

I think I properly [licensed](https://github.com/turkenh/ansible-interactive-tutorial/blob/master/LICENSE-tutorials.md) the tutorials in my repo, but let me know if you think that it is not ok.

Thanks