### PR TITLE
incorrect depedency for ubuntu 18.04

### DIFF
--- a/step-08/apache.yml
+++ b/step-08/apache.yml
@@ -7,7 +7,7 @@
 
     - name: Installs necessary packages
       apt:
-        pkg: ["apache2", "libapache2-mod-php5", "git"]
+        pkg: ["apache2", "libapache2-mod-php", "git"]
         state: latest
 
     - name: Push future default virtual host configuration

--- a/step-09/apache.yml
+++ b/step-09/apache.yml
@@ -7,7 +7,7 @@
 
     - name: Installs necessary packages
       apt:
-        pkg: ["apache2", "libapache2-mod-php5", "git"]
+        pkg: ["apache2", "libapache2-mod-php", "git"]
         state: latestmod-php5
 
     - name: Push future default virtual host configuration

--- a/step-09/apache.yml
+++ b/step-09/apache.yml
@@ -8,8 +8,8 @@
     - name: Installs necessary packages
       apt:
         pkg: ["apache2", "libapache2-mod-php", "git"]
-        state: latestmod-php5
-
+        state: latest
+        
     - name: Push future default virtual host configuration
       copy:
         src: files/awesome-app

--- a/step-10/apache.yml
+++ b/step-10/apache.yml
@@ -7,7 +7,7 @@
 
     - name: Installs necessary packages
       apt:
-        pkg: ["apache2", "libapache2-mod-php5", "git"]
+        pkg: ["apache2", "libapache2-mod-php", "git"]
         state: latest
 
     - name: Push future default virtual host configuration

--- a/step-11/apache.yml
+++ b/step-11/apache.yml
@@ -7,7 +7,7 @@
 
     - name: Installs necessary packages
       apt:
-        pkg: ["apache2", "libapache2-mod-php5", "git"]
+        pkg: ["apache2", "libapache2-mod-php", "git"]
         state: latest
 
     - name: Push future default virtual host configuration

--- a/step-12/roles/apache/tasks/main.yml
+++ b/step-12/roles/apache/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Installs necessary packages
   apt:
-    pkg: ["apache2", "libapache2-mod-php5", "git"]
+    pkg: ["apache2", "libapache2-mod-php", "git"]
     state: latest
 
 - name: Push future default virtual host configuration


### PR DESCRIPTION
Following the tutorial with Vagrant and 18.04 ubuntu vms leads to the following error on step 8: 

`fatal: [host1.example.org]: FAILED! => {"changed": false, "msg": "No package matching 'libapache2-mod-php5' is available"}`

libapache2-mod-php works as expected.