### PR TITLE
Update ENV variable

### DIFF
--- a/step-01/README.md
+++ b/step-01/README.md
@@ -2,7 +2,7 @@
 
 Before continuing, you need an inventory file. The default place for such a
 file is  `/etc/ansible/hosts`. However, you can configure ansible to look
-somewhere else, use an environment variable (`ANSIBLE_HOSTS`), or use the `-i`
+somewhere else, use an environment variable (`ANSIBLE_INVENTORY`), or use the `-i`
 flag in ansible commands an provide the inventory path.
 
 We've created an inventory file for you in the directory that looks like this:


### PR DESCRIPTION
Following Ansible 2.7.1 preco 

> [DEPRECATION WARNING]: ANSIBLE_HOSTS option, The variable is misleading as it can be a list of hosts and/or paths to inventory 
> sources , use ANSIBLE_INVENTORY instead. This feature will be removed in version 2.8. Deprecation warnings can be disabled by 
> setting deprecation_warnings=False in ansible.cfg.