### PR TITLE
fix plugin settings and deploy on github pages

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,12 +1,13 @@
 {
     "gitbook": "3.0.x",
     "plugins": [
+        "-sharing",
         "edit-link@2.0.x",
         "github@2.0.x"
     ],
     "pluginsConfig": {
             "edit-link": {
-                "base": "https://github.com/leucos/ansible-tuto/tree/writing",
+                "base": "https://github.com/leucos/ansible-tuto/edit/master",
                 "label": "Edit"
             },
             "github": {


### PR DESCRIPTION
@leucos as gitbook.com has become more of a private thing, I suggest you to host your tutorial on [github pages](https://pages.github.com/). You can check it hosted [here](https://tumregels.github.io/ansible-tuto/)

To do it on your end you need just merge this pull request and then

```
    $ git clone https://github.com/leucos/ansible-tuto.git
    $ cd ansible-tuto
    $ npm install
    $ npm run docs:build
    $ npm run docs:publish
```