### PR TITLE
Fix error because ansible_host variable is unknown

### DIFF
--- a/step-10/README.md
+++ b/step-10/README.md
@@ -42,7 +42,7 @@ listen cluster
     stats enable
     balance roundrobin
 {% for backend in groups['web'] %}
-    server {{ hostvars[backend]['ansible_hostname'] }} {{ hostvars[backend].ansible_host }} check port 80
+    server {{ hostvars[backend]['ansible_hostname'] }} {{ hostvars[backend]['ansible_facts']['default_ipv4']['address'] }} check port 80
 {% endfor %}
     option httpchk HEAD /index.php HTTP/1.0
 ```

--- a/step-10/templates/haproxy.cfg.j2
+++ b/step-10/templates/haproxy.cfg.j2
@@ -14,7 +14,7 @@ listen cluster
     stats enable
     balance roundrobin
 {% for backend in groups['web'] %}
-    server {{ hostvars[backend]['ansible_hostname'] }} {{ hostvars[backend].ansible_host }} check port 80
+    server {{ hostvars[backend]['ansible_hostname'] }} {{ hostvars[backend]['ansible_facts']['default_ipv4']['address'] }} check port 80
 {% endfor %}
     option httpchk HEAD /index.php HTTP/1.0
 


### PR DESCRIPTION
Hi,

With the latest version of Ansible (7.2.0), the variable **ansible_host** seems to be not defined in **haproxy.cfg.j2**, because we have this error message:

`FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_host'"}`

This pull request fixes that.

Thanks for the merge.